### PR TITLE
Update build-pk3-assets.sh for backwards compatibility

### DIFF
--- a/docker-scripts/build/build-pk3-assets.sh
+++ b/docker-scripts/build/build-pk3-assets.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PK3_NAME=rtcwpro_assets.pk3
+PK3_NAME=rtcwpro_assets.125plus.pk3
 OUTPUT_FOLDER=/rtcwpro/output
 CONTENT_FOLDER=/rtcwpro/MAIN
 

--- a/docker-scripts/build/build-pk3-bin.sh
+++ b/docker-scripts/build/build-pk3-bin.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PK3_NAME=rtcwpro_bin.pk3
+PK3_NAME=rtcwpro_bin.post125.pk3
 OUTPUT_FOLDER=/rtcwpro/output
 CONTENT_FOLDER=/rtcwpro/MAIN
 


### PR DESCRIPTION
This is for compatibility with the RtcwPro-Omnibots server, for now (until that server shuts down). There are many duplicated assets that increase 1.2.9's rtcwpro_assets.pk3's filesize and haven't changed with even 1.2.7...

For that reason, I propose going back to re-using the old PK3 and ONLY adding stuff to this newer one.